### PR TITLE
Use a consistent spelling of acknowledgments

### DIFF
--- a/DCOAboutWindow.podspec
+++ b/DCOAboutWindow.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |s|
   s.summary         = "Introduces a prettier About Window."
   s.description     = <<-DESC
                        A replacement for the standard About dialog. Adds the option to open
-                       acknowledgements and visit the website by clicking a button.
+                       acknowledgments and visit the website by clicking a button.
                        DESC
   s.homepage        = "http://github.com/DangerCove/DCOAboutWindow"
   s.license         = 'BSD'

--- a/DCOAboutWindow/DCOAboutWindow.xib
+++ b/DCOAboutWindow/DCOAboutWindow.xib
@@ -7,7 +7,7 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="DCOAboutWindowController">
             <connections>
-                <outlet property="acknowledgementsButton" destination="rvK-GI-M19" id="aOq-p2-IVi"/>
+                <outlet property="acknowledgmentsButton" destination="rvK-GI-M19" id="aOq-p2-IVi"/>
                 <outlet property="creditsTextView" destination="pHV-oS-ckv" id="jZi-EY-CLl"/>
                 <outlet property="infoView" destination="azJ-mF-gLH" id="fAk-OO-opT"/>
                 <outlet property="visitWebsiteButton" destination="DNh-ZA-cca" id="wD5-ro-jbQ"/>
@@ -144,12 +144,12 @@
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="rvK-GI-M19">
                                 <rect key="frame" x="383" y="8" width="163" height="32"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                <buttonCell key="cell" type="push" title="Acknowledgements" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Wky-VX-jr0">
+                                <buttonCell key="cell" type="push" title="Acknowledgments" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Wky-VX-jr0">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>
                                 <connections>
-                                    <action selector="showAcknowledgements:" target="-2" id="bgN-HQ-OGs"/>
+                                    <action selector="showAcknowledgments:" target="-2" id="bgN-HQ-OGs"/>
                                 </connections>
                             </button>
                         </subviews>

--- a/DCOAboutWindow/DCOAboutWindowController.h
+++ b/DCOAboutWindow/DCOAboutWindowController.h
@@ -44,10 +44,10 @@
 @property (strong) NSURL *appWebsiteURL;
 
 /** 
- *  The path to the file that contains the acknowledgements. 
- *  Default: [[NSBundle mainBundle] pathForResource:@"Acknowledgements" ofType:@"rtf"];
+ *  The path to the file that contains the acknowledgments. 
+ *  Default: [[NSBundle mainBundle] pathForResource:@"Acknowledgments" ofType:@"rtf"];
  */
-@property (nonatomic, copy) NSString *acknowledgementsPath;
+@property (nonatomic, copy) NSString *acknowledgmentsPath;
 
 /**
  *  Visit the website.
@@ -57,10 +57,10 @@
 - (IBAction)visitWebsite:(id)sender;
 
 /**
- *  Show acknowledgements for libraries used etc.
+ *  Show acknowledgments for libraries used etc.
  *
  *  @param sender The object making the call.
  */
-- (IBAction)showAcknowledgements:(id)sender;
+- (IBAction)showAcknowledgments:(id)sender;
 
 @end

--- a/DCOAboutWindow/DCOAboutWindowController.m
+++ b/DCOAboutWindow/DCOAboutWindowController.m
@@ -22,8 +22,8 @@
 /** The button that opens the app's website. */
 @property (weak) IBOutlet NSButton *visitWebsiteButton;
 
-/** The button that opens the acknowledgements. */
-@property (weak) IBOutlet NSButton *acknowledgementsButton;
+/** The button that opens the acknowledgments. */
+@property (weak) IBOutlet NSButton *acknowledgmentsButton;
 
 @end
 
@@ -66,9 +66,9 @@
     // Set "visit website" caption
     self.visitWebsiteButton.title = [NSString stringWithFormat:self.visitWebsiteButton.title, self.appName];
     
-    // Set acknowledgements
-    if(!self.acknowledgementsPath) {
-        self.acknowledgementsPath = [[NSBundle mainBundle] pathForResource:@"Acknowledgements" ofType:@"rtf"];
+    // Set acknowledgments
+    if(!self.acknowledgmentsPath) {
+        self.acknowledgmentsPath = [[NSBundle mainBundle] pathForResource:@"Acknowledgments" ofType:@"rtf"];
     }
 
     // Set credits
@@ -95,13 +95,13 @@
 
 #pragma mark - Getters/Setters
 
-- (void)setAcknowledgementsPath:(NSString *)acknowledgementsPath {
-    _acknowledgementsPath = acknowledgementsPath;
+- (void)setAcknowledgmentsPath:(NSString *)acknowledgmentsPath {
+    _acknowledgmentsPath = acknowledgmentsPath;
     
-    if(!acknowledgementsPath) {
+    if(!acknowledgmentsPath) {
         
         // Remove the button (and constraints)
-        [self.acknowledgementsButton removeFromSuperview];
+        [self.acknowledgmentsButton removeFromSuperview];
         
     }
 }
@@ -118,15 +118,15 @@
     
 }
 
-- (IBAction)showAcknowledgements:(id)sender {
+- (IBAction)showAcknowledgments:(id)sender {
     
-    if(self.acknowledgementsPath) {
+    if(self.acknowledgmentsPath) {
         
         // Load in default editor
-        [[NSWorkspace sharedWorkspace] openFile:self.acknowledgementsPath];
+        [[NSWorkspace sharedWorkspace] openFile:self.acknowledgmentsPath];
         
     } else {
-        NSLog(@"Error: couldn't load the acknowledgements file");
+        NSLog(@"Error: couldn't load the acknowledgments file");
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 DCOAboutWindow is a replacement for the standard About dialog. 
 
-It adds the option to open acknowledgements and visit the website by clicking a button.
+It adds the option to open acknowledgments and visit the website by clicking a button.
 
 ![DCOAboutWindow in action](https://raw.github.com/DangerCove/DCOAboutWindow/master/screenshots/DCOAboutWindow.jpg)
 
@@ -80,10 +80,10 @@ You can change values by setting properties on `DCOAboutWindowController`:
     @property (strong) NSURL *appWebsiteURL;
 
     /** 
-     *  The path to the file that contains the acknowledgements. 
-     *  Default: [[NSBundle mainBundle] pathForResource:@"Acknowledgements" ofType:@"rtf"];
+     *  The path to the file that contains the acknowledgments. 
+     *  Default: [[NSBundle mainBundle] pathForResource:@"Acknowledgments" ofType:@"rtf"];
      */
-    @property (nonatomic, copy) NSString *acknowledgementsPath;
+    @property (nonatomic, copy) NSString *acknowledgmentsPath;
 
 
 


### PR DESCRIPTION
There were a lot of uses of acknowledg**e**ments in this class, which I think is the wrong spelling. (Or at least a less common spelling.)

It was definitely conflicting with https://github.com/DangerCove/Acknowledge which generates `Acknowledgments.rtf` (No "E") but this code was looking for a `Acknowledgements.rtf` (With an "E").
