### PR TITLE
Fix podspec to actually use 0.4.0 instead of 0.3.1.

### DIFF
--- a/DCOAboutWindow.podspec
+++ b/DCOAboutWindow.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.license         = 'BSD'
   s.author          = { "Boy van Amstel" => "boy@dangercove.com" }
   s.platform        = :osx, "10.8"
-  s.source          = { :git => "https://github.com/DangerCove/DCOAboutWindow.git", :tag => "0.3.1" }
+  s.source          = { :git => "https://github.com/DangerCove/DCOAboutWindow.git", :tag => "0.4.0" }
   s.source_files    = 'DCOAboutWindow/*.{h,m}'
   s.resources       = "DCOAboutWindow/*.{xib}"
   s.framework       = 'QuartzCore'


### PR DESCRIPTION
The podspec in the repo now mentions 0.4.0 as the current version, but the source line points to the 0.3.1 tag, and as such that's what gets installed via Cocoapods.